### PR TITLE
Remove buffer overflow and simplify bootstrapping DPC++ example

### DIFF
--- a/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
+++ b/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
@@ -12,7 +12,7 @@ constexpr size_t N { 14 };
 // bootstrap_function returns a char buffer thru an input buffer
 
 void bootstrap_function(char *result) {
-    char bootstrap[N] = {'B','o','o','t','s','t','r','a','p','p','i','n','g','!','\0'};
+    char bootstrap[N] = {'B','o','o','t','s','t','r','a','p','p','i','n','g','!'};
     for( size_t i = 0; i < N; ++i ) { result[i] = bootstrap[i]; }
  }
 

--- a/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
+++ b/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
@@ -23,8 +23,8 @@ int main(int argc, char** argv) {
         // default_selector my_selector;
         queue my_queue;
         std::cout << "Device : " << my_queue.get_device().get_info<info::device::name>() << std::endl;
-        
-        char result[14];        
+
+        char result[14];
         buffer<char, 1> my_buffer(result, range<1>(N));
         my_queue.submit([&] (handler &my_handler){
                 auto my_accessor = my_buffer.get_access<access::mode::read_write>(my_handler);
@@ -34,9 +34,9 @@ int main(int argc, char** argv) {
         });
         my_queue.wait_and_throw();
         my_buffer.get_access<access::mode::read>();
-        
-        for(auto i = 0; i < N; ++i) { std::cout << result[i]; } 
+
+        for(auto i = 0; i < N; ++i) { std::cout << result[i]; }
         std::cout << std::endl;
-        
+
         return 0;
 }

--- a/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
+++ b/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
@@ -20,23 +20,24 @@ void bootstrap_function(char *result) {
 // entry point for the program
 
 int main(int argc, char** argv) {
-        // default_selector my_selector;
-        queue my_queue;
-        std::cout << "Device : " << my_queue.get_device().get_info<info::device::name>() << std::endl;
+  // default_selector my_selector;
+  queue my_queue;
+  std::cout << "Device : " << my_queue.get_device().get_info<info::device::name>() << std::endl;
 
-        char result[N];
-        buffer<char, 1> my_buffer(result, range<1>(N));
-        my_queue.submit([&] (handler &my_handler){
-                auto my_accessor = my_buffer.get_access<access::mode::read_write>(my_handler);
-                my_handler.single_task<class bootstrap>([=](){
-                        bootstrap_function(&my_accessor[0]);
-                });
-        });
-        my_queue.wait_and_throw();
-        my_buffer.get_access<access::mode::read>();
+  char result[N];
+  {
+    buffer<char, 1> my_buffer(result, range<1>(N));
+    my_queue.submit([&] (handler &my_handler){
+      auto my_accessor = my_buffer.get_access<access::mode::read_write>(my_handler);
+      my_handler.single_task<class bootstrap>([=]{
+        bootstrap_function(&my_accessor[0]);
+      });
+    });
+  } // Copy back to result on buffer destruction
 
-        for(auto i = 0; i < N; ++i) { std::cout << result[i]; }
-        std::cout << std::endl;
+  for (auto c : result)
+    std::cout << c;
+  std::cout << std::endl;
 
-        return 0;
+  return 0;
 }

--- a/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
+++ b/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
@@ -11,25 +11,26 @@ constexpr size_t N { 14 };
 // ############################################################
 // bootstrap_function returns a char buffer thru an input buffer
 
-void bootstrap_function(char *result) {
-    char bootstrap[N] = {'B','o','o','t','s','t','r','a','p','p','i','n','g','!'};
-    for( size_t i = 0; i < N; ++i ) { result[i] = bootstrap[i]; }
- }
+void bootstrap_function(char result[]) {
+  char bootstrap[N] = {'B','o','o','t','s','t','r','a','p','p','i','n','g','!'};
+  for (size_t i = 0; i < N; ++i) { result[i] = bootstrap[i]; }
+}
 
 // ############################################################
 // entry point for the program
 
 int main(int argc, char** argv) {
-  // default_selector my_selector;
   queue my_queue;
-  std::cout << "Device : " << my_queue.get_device().get_info<info::device::name>() << std::endl;
+  std::cout << "Device : "
+            << my_queue.get_device().get_info<info::device::name>()
+            << std::endl;
 
   char result[N];
   {
     buffer<char, 1> my_buffer(result, range<1>(N));
     my_queue.submit([&] (handler &my_handler){
       auto my_accessor = my_buffer.get_access<access::mode::read_write>(my_handler);
-      my_handler.single_task<class bootstrap>([=]{
+      my_handler.single_task<class bootstrap>([=] {
         bootstrap_function(&my_accessor[0]);
       });
     });

--- a/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
+++ b/DPC++Compiler/bootstrapping/src/bootstrapping.cpp
@@ -6,7 +6,7 @@
 
 #include <CL/sycl.hpp>
 using namespace cl::sycl;
-constexpr size_t N { 15 };
+constexpr size_t N { 14 };
 
 // ############################################################
 // bootstrap_function returns a char buffer thru an input buffer
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
         queue my_queue;
         std::cout << "Device : " << my_queue.get_device().get_info<info::device::name>() << std::endl;
 
-        char result[14];
+        char result[N];
         buffer<char, 1> my_buffer(result, range<1>(N));
         my_queue.submit([&] (handler &my_handler){
                 auto my_accessor = my_buffer.get_access<access::mode::read_write>(my_handler);


### PR DESCRIPTION
This fixes the buffer accessor overflow in the kernel.
It removes also the complex and unnecessary explicit queue synchronization and host accessor.
These are some problems I found while following the tutorial during SC19.
The risk of using old style C programming like in this example is to have this kind of C-style bugs...