### PR TITLE
updated default oneAPI installation path

### DIFF
--- a/oneDNN/oneDNN_Getting_Started/oneDNN_Getting_Started.ipynb
+++ b/oneDNN/oneDNN_Getting_Started/oneDNN_Getting_Started.ipynb
@@ -45,12 +45,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "env: ONEAPI_INSTALL=/home/intel/intel/inteloneapi/\n"
+      "env: ONEAPI_INSTALL=/opt/intel/inteloneapi\n"
      ]
     }
    ],
    "source": [
-    "%env ONEAPI_INSTALL=/home/intel/intel/inteloneapi/"
+    "%env ONEAPI_INSTALL=/opt/intel/inteloneapi"
    ]
   },
   {
@@ -64,10 +64,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/intel/intel/inteloneapi//oneDNN/latest/cpu_dpcpp_gpu_dpcpp\r\n",
-      "/home/intel/intel/inteloneapi//oneDNN/latest/cpu_gomp\r\n",
-      "/home/intel/intel/inteloneapi//oneDNN/latest/cpu_iomp\r\n",
-      "/home/intel/intel/inteloneapi//oneDNN/latest/cpu_tbb\r\n"
+      "/opt/intel/inteloneapi/oneDNN/latest/cpu_dpcpp_gpu_dpcpp\r\n",
+      "/opt/intel/inteloneapi/oneDNN/latest/cpu_gomp\r\n",
+      "/opt/intel/inteloneapi/oneDNN/latest/cpu_iomp\r\n",
+      "/opt/intel/inteloneapi/oneDNN/latest/cpu_tbb\r\n"
      ]
     }
    ],
@@ -446,30 +446,30 @@
      "text": [
       "-- The C compiler identification is Clang 10.0.0\n",
       "-- The CXX compiler identification is Clang 10.0.0\n",
-      "-- Check for working C compiler: /home/intel/intel/inteloneapi/compiler/latest/linux/bin/clang\n",
-      "-- Check for working C compiler: /home/intel/intel/inteloneapi/compiler/latest/linux/bin/clang -- works\n",
+      "-- Check for working C compiler: /opt/intel/inteloneapi/compiler/latest/linux/bin/clang\n",
+      "-- Check for working C compiler: /opt/intel/inteloneapi/compiler/latest/linux/bin/clang -- works\n",
       "-- Detecting C compiler ABI info\n",
       "-- Detecting C compiler ABI info - done\n",
       "-- Detecting C compile features\n",
       "-- Detecting C compile features - done\n",
-      "-- Check for working CXX compiler: /home/intel/intel/inteloneapi/compiler/latest/linux/bin/dpcpp\n",
-      "-- Check for working CXX compiler: /home/intel/intel/inteloneapi/compiler/latest/linux/bin/dpcpp -- works\n",
+      "-- Check for working CXX compiler: /opt/intel/inteloneapi/compiler/latest/linux/bin/dpcpp\n",
+      "-- Check for working CXX compiler: /opt/intel/inteloneapi/compiler/latest/linux/bin/dpcpp -- works\n",
       "-- Detecting CXX compiler ABI info\n",
       "-- Detecting CXX compiler ABI info - done\n",
       "-- Detecting CXX compile features\n",
       "-- Detecting CXX compile features - done\n",
       "-- CMAKE_BUILD_TYPE is unset, defaulting to Release\n",
-      "-- DNNLROOT: /home/intel/intel/inteloneapi/oneDNN/2021.1-beta04/cpu_dpcpp_gpu_dpcpp\n",
+      "-- DNNLROOT: /opt/intel/inteloneapi/oneDNN/2021.1-beta04/cpu_dpcpp_gpu_dpcpp\n",
       "-- Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES) \n",
       "-- Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES) \n",
       "-- Could NOT find OpenMP (missing: OpenMP_C_FOUND OpenMP_CXX_FOUND) \n",
       "-- Looking for CL_VERSION_2_2\n",
       "-- Looking for CL_VERSION_2_2 - found\n",
-      "-- Found OpenCL: /home/intel/intel/inteloneapi/compiler/latest/linux/lib/libOpenCL.so (found version \"2.2\") \n",
+      "-- Found OpenCL: /opt/intel/inteloneapi/compiler/latest/linux/lib/libOpenCL.so (found version \"2.2\") \n",
       "-- Performing Test DPCPP_SUPPORTED\n",
       "-- Performing Test DPCPP_SUPPORTED - Success\n",
-      "-- Found DPCPP: /home/intel/intel/inteloneapi/compiler/latest/linux/lib/libsycl.so  \n",
-      "-- Found SYCL: /home/intel/intel/inteloneapi/compiler/latest/linux/lib/libsycl.so  \n",
+      "-- Found DPCPP: /opt/intel/inteloneapi/compiler/latest/linux/lib/libsycl.so  \n",
+      "-- Found SYCL: /opt/intel/inteloneapi/compiler/latest/linux/lib/libsycl.so  \n",
       "-- Configuring done\n",
       "-- Generating done\n",
       "-- Build files have been written to: /home/intel/WORK/oneAPI/eco/DLDevKit-code-samples/oneDNN_Getting_Started/dpcpp\n",
@@ -607,7 +607,7 @@
       "-- Detecting CXX compile features\n",
       "-- Detecting CXX compile features - done\n",
       "-- CMAKE_BUILD_TYPE is unset, defaulting to Release\n",
-      "-- DNNLROOT: /home/intel/intel/inteloneapi/oneDNN/2021.1-beta04/cpu_gomp\n",
+      "-- DNNLROOT: /opt/intel/inteloneapi/oneDNN/2021.1-beta04/cpu_gomp\n",
       "-- Found OpenMP_C: -fopenmp (found version \"4.5\") \n",
       "-- Found OpenMP_CXX: -fopenmp (found version \"4.5\") \n",
       "-- Found OpenMP: TRUE (found version \"4.5\")  \n",
@@ -660,7 +660,7 @@
     "%%writefile build.sh\n",
     "#!/bin/bash\n",
     "source $ONEAPI_INSTALL/setvars.sh --dnnl-configuration=cpu_iomp --force> /dev/null 2>&1\n",
-    "#source ~/intel/inteloneapi/setvars.sh  --dnnl-configuration=cpu_iomp > /dev/null 2>&1\n",
+    "#source $ONEAPI_INSTALL/setvars.sh  --dnnl-configuration=cpu_iomp > /dev/null 2>&1\n",
     "export EXAMPLE_ROOT=./lab/\n",
     "mkdir cpu_iomp\n",
     "cd cpu_iomp\n",


### PR DESCRIPTION
This PR updates default installation path for oneAPI in oneDNN Getting Started Jupyter notebook to `/opt/intel/inteloneapi`, which is default and used on oneAPI DevCloud.

The issue was reported at oneDNN Gitthub: https://github.com/oneapi-src/oneDNN/issues/744.
