### PR TITLE
Fix minor bug in device_link example README.md. 

### DIFF
--- a/FPGATutorials/Compilation/device_link/README.md
+++ b/FPGATutorials/Compilation/device_link/README.md
@@ -53,7 +53,7 @@ The compilation is a 3-step process:
 2. Compile host part (seconds) using:
    
    ``` 
-   dpcpp -fintelfpga main.cpp -c host.o
+   dpcpp -fintelfpga main.cpp -c -o host.o
    ```
    For generic program, input files should include all source files that only contain host code.
 


### PR DESCRIPTION
Added missing "-o" in 2-step process in compiling host part.